### PR TITLE
Prevented message spamming and clarified join message

### DIFF
--- a/Identify VR Players/clientnetworksession.lua
+++ b/Identify VR Players/clientnetworksession.lua
@@ -1,5 +1,13 @@
-Hooks:PostHook(ClientNetworkSession,"on_peer_synched","client_informvr",function(self, peer_id, ...)
-	if _G.IS_VR then 
-		managers.chat:send_message(1,managers.network:session():local_peer(),"I am using VR!")
-	end
+local lastExecutionTime = 0
+
+Hooks:PostHook(ClientNetworkSession, "on_peer_synched", "client_informvr", function(self, peer_id, ...)
+    if _G.IS_VR then
+        DelayedCalls:Add("VR_message_delay", 5, function()
+            local currentTime = os.time()
+            if (currentTime - lastExecutionTime) >= 5 then
+                managers.chat:send_message(1, managers.network:session():local_peer(), "[Identify VR Players Mod] I am using VR")
+                lastExecutionTime = currentTime
+            end
+        end)
+    end
 end)

--- a/Identify VR Players/hostnetworksession.lua
+++ b/Identify VR Players/hostnetworksession.lua
@@ -1,5 +1,13 @@
-Hooks:PostHook(HostNetworkSession, "on_peer_sync_complete", "host_informvr" , function(self, peer, peer_id)
-	if _G.IS_VR then
-		managers.chat:send_message( 1, managers.network:session():local_peer(), "I am using VR!")
-	end
+local lastExecutionTime = 0
+
+Hooks:PostHook(HostNetworkSession, "on_peer_sync_complete", "host_informvr", function(self, peer, peer_id)
+    if _G.IS_VR then
+        DelayedCalls:Add("VR_message_delay", 5, function()
+            local currentTime = os.time()
+            if (currentTime - lastExecutionTime) >= 5 then
+                managers.chat:send_message(1, managers.network:session():local_peer(), "[Identify VR Players Mod] I am using VR")
+                lastExecutionTime = currentTime
+            end
+        end)
+    end
 end)

--- a/Identify VR Players/networkpeer.lua
+++ b/Identify VR Players/networkpeer.lua
@@ -1,5 +1,5 @@
 Hooks:PreHook(NetworkPeer,"set_is_vr","idvr_setvr",function(self)
 	if not self._is_vr then --if using posthook or without this check, always outputs the message twice. I don't like that.
-		managers.chat:_receive_message(1,"[ID_VR]", tostring(self._name) .. " is using VR!", Color('29FFC9'))
+		managers.chat:_receive_message(1,"[Identify VR Players Mod]", tostring(self._name) .. " is using VR", Color('29FFC9'))
 	end
 end)


### PR DESCRIPTION
The script takes a 5-second break before sending the join message. If the same message was sent less than 5 seconds ago, it won't send it again.

Also, I've put '[Identify VR Players Mod]' at the start of the messages. This shows that a mod, not a player, automatically sends the message.